### PR TITLE
[SAPCC] Configure Sentry via oslo.log

### DIFF
--- a/oslo_log/sentry.py
+++ b/oslo_log/sentry.py
@@ -1,0 +1,41 @@
+import sentry_sdk
+
+from sentry_sdk.consts import VERSION
+from sentry_sdk.integrations.logging import EventHandler, BreadcrumbHandler
+
+
+def version_to_tuple(version):
+    return tuple(map(int, version.split('.')))
+
+
+class SentryHandler(EventHandler):
+    """
+    The Sentry library 'raven' is long deprecated.
+    Relying on the new standard Sentry EventHandler does not work, as compared to 'raven', no Sentry client is initialized
+    To overcome this, a decision was made to mimic the 'raven' behavior with a custom Eventhandler
+    """
+    def __init__(self):
+        super().__init__()
+        if not self.is_client_initialized():
+            # There is no need to use the default Sentry LoggingIntegration for our usecase
+            # According to the source code the integration overwrites the callHandlers of standard logging library
+            # logging.Logger.callHandlers = sentry_patched_callhandlers
+            # Source: https://github.com/getsentry/sentry-python/blob/200d0cdde8eed2caa89b91db8b17baabe983d2de/sentry_sdk/integrations/logging.py#L111
+            # It is enough to configure the Handler sentry_sdk.integrations.logging.EventHandler via log.ini
+            # Calling the handler happens via the standard python logging library makes sure the Eventhandler
+            sentry_sdk.init(
+                integrations=[],
+                # disable all default integrations (e.g. sentry_sdk.integrations.excepthook.ExcepthookIntegration)
+                default_integrations=False,
+                # disable all auto enabling integrations (e.g. sentry_sdk.integrations.flask.FlaskIntegration)
+                auto_enabling_integrations=False,
+                debug=False,
+            )
+
+    @staticmethod
+    def is_client_initialized():
+        if version_to_tuple(VERSION) > version_to_tuple('1.45.1'):
+            return True if sentry_sdk.get_client() is not None else False
+        else:
+            hub = sentry_sdk.Hub.current
+            return True if hub.client is not None else False

--- a/oslo_log/tests/unit/test_sentry_handler.py
+++ b/oslo_log/tests/unit/test_sentry_handler.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+from oslotest import base as test_base
+from oslo_log.sentry import SentryHandler
+import sentry_sdk
+
+
+class SentryHandlerTest(test_base.BaseTestCase):
+
+    def setUp(self):
+        super(SentryHandlerTest, self).setUp()
+
+    @patch.object(sentry_sdk, 'init', return_value=None)
+    def test_init_sdk_called(self, mock_init):
+        SentryHandler()
+        mock_init.assert_called_once()
+
+    def test_init_sdk_not_called(self):
+        self.assertEqual(SentryHandler.is_client_initialized(), False)
+
+    @patch.object(sentry_sdk.integrations.logging.EventHandler, 'emit')
+    def test_logging_error_message(self, mock_emit):
+        import logging
+
+        logger = logging.getLogger('test_logger')
+        logger.setLevel(logging.ERROR)
+
+        sentry_handler = SentryHandler()
+        sentry_handler.setLevel(logging.ERROR)
+
+        logger.addHandler(sentry_handler)
+
+        logger.error("Test Message")
+        mock_emit.assert_called_once()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ oslo.serialization>=2.25.0 # Apache-2.0
 debtcollector>=1.19.0 # Apache-2.0
 pyinotify>=0.9.6;sys_platform!='win32' and sys_platform!='darwin' and sys_platform!='sunos5' # MIT
 python-dateutil>=2.7.0 # BSD
+# Newer versions will not work with our Senry
+sentry-sdk==1.45.1 # MIT


### PR DESCRIPTION
The Sentry Raven client library, replaced by the python sentry_sdk, is long deprecated. Comparing both libraries, creating a sentry client happens during the sentry_sdk.init() call whereas in raven the eventhandler created one if needed. Furthermore, for us it is important to capture logs and exceptions only for selected loggers (configured via Handlers). With the new sdk lots of logging integration get loaded automatically if not disabled explicitly. We also want to call init() with the right configuration for us.

Avoiding the sentry configuration in each SAPCC upstream based project (e.g. Neutron or Nova) and each driver, we simply implement our own Handler 'oslo_log.sentry.SentryHandler', which can be consumed as every logging Handler e.g. in a log.ini file.